### PR TITLE
make homepage cards link to the city pages

### DIFF
--- a/source/assets/javascripts/landing.js
+++ b/source/assets/javascripts/landing.js
@@ -1,0 +1,10 @@
+(function() {
+  function navigateToPage(page) {
+    return function() {
+      window.location.href = '/' + page + '.html';
+    }
+  }
+
+  $('.hero-card--nyc').click(navigateToPage('nyc'));
+  $('.hero-card--la').click(navigateToPage('la'));
+})();

--- a/source/assets/stylesheets/landing.scss
+++ b/source/assets/stylesheets/landing.scss
@@ -138,6 +138,7 @@ $tablet-width: $small-section-width;
 .hero-card {
   box-sizing: border-box;
   width: 100%;
+  cursor: pointer;
 
   margin-top: 42px;
   &:first-child {

--- a/source/index.html.erb
+++ b/source/index.html.erb
@@ -91,5 +91,9 @@
 
   <!-- GOOD STUFF HERE -->
 
+
+  <!-- JS -->
+  <%= javascript_include_tag "vendor/jquery-2.2.1.min.js" %>
+  <%= javascript_include_tag "landing.js" %>
 </body>
 </html>


### PR DESCRIPTION
## Goals
Make the LA and NYC cards on the homepage into links to their respective city pages

## Implementation
- Nested anchor tags are invalid HTML, and the browser refuses to render them correctly. So since we want to have the nested Buy Tickets links, make the outer cards clickable with a little JS

## For discussion
- Since the outer card isn't a real link, I left the More Information links in there, to keep things a little more accessible. I also think it looks better.