### PR TITLE
add disabled tix button to LA

### DIFF
--- a/source/la.html.erb
+++ b/source/la.html.erb
@@ -46,9 +46,16 @@
       </h1>
 
       <p>
-        <a class="button button-tertiary button-large current-event no-hover" target="_blank" href="https://docs.google.com/forms/d/e/1FAIpQLSfjqGB4siWwoDridg-LSCR1muijzebBm6iYRE6Iru6svz8Syw/viewform">
-          Submit a proposal
-        </a>
+        <div>
+          <a class="button button-tertiary button-large current-event no-hover" target="_blank" href="https://docs.google.com/forms/d/e/1FAIpQLSfjqGB4siWwoDridg-LSCR1muijzebBm6iYRE6Iru6svz8Syw/viewform">
+            Submit a proposal
+          </a>
+        </div>
+        <div>
+          <a class="button button-tertiary button-large current-event no-hover">
+            Tickets on Sale December 1
+          </a>
+        </div>
       </p>
     </header>
   </section>


### PR DESCRIPTION
Adds a (temporarily) un-linked button for buying tickets to the LA homepage

![tix](https://user-images.githubusercontent.com/5178425/33118008-4a46c04a-cf1f-11e7-88aa-7e1c3e36edb5.png)
