### PR TITLE
add the date below the header

### DIFF
--- a/source/la.html.erb
+++ b/source/la.html.erb
@@ -74,6 +74,9 @@
           A one-day conference for curious<br class="hide-mobile" / >
           elixir programmers.
         </h2>
+        <p>
+        Saturday, February 10, 2018
+        </p>
       </div>
 
       <div class="hero__buttons">


### PR DESCRIPTION
I went to the website to find the date and was annoyed that the date is nowhere above the fold, so I added it.

I left the date below the fold as well, I figure it can't hurt to have that info in two places.

Design is up for discussion if anyone wants to do something different with it.

<img width="1769" alt="screen shot 2017-12-12 at 9 19 57 am" src="https://user-images.githubusercontent.com/17886804/33898555-a863a31a-df1d-11e7-893d-8b4e705ae020.png">
