### PR TITLE
fix title color

### DIFF
--- a/source/assets/stylesheets/_presentations.scss
+++ b/source/assets/stylesheets/_presentations.scss
@@ -19,7 +19,7 @@
 }
 
 .presentation__title {
-  color: $primaryColor;
+  color: $primaryColor !important;
   font-size: 1.5em;
 }
 

--- a/source/assets/stylesheets/la.scss
+++ b/source/assets/stylesheets/la.scss
@@ -14,7 +14,7 @@ h1, h2, h3, h4, h5, h6 {
 
 @mixin section-color($color) {
   color: $color;
-  p, h1, h3, h4, h5, h6 {
+  p, h1, h2, h3, h4, h5, h6 {
     color: $color;
   }
 }
@@ -293,6 +293,7 @@ h1, h2, h3, h4, h5, h6 {
 
 .presentations {
   @include small-section();
+  @include section-color($color0);
 }
 
 .sponsor-section {


### PR DESCRIPTION
Fix title color in presentations sections

Looks like I didn't include `section-color` because it was overriding the green presentation titles. Make those important so we can use section-color, which styles the h2s

![screen shot 2018-01-05 at 10 39 22 am](https://user-images.githubusercontent.com/5178425/34623119-bd33a994-f204-11e7-824f-92444754bffd.png)

  