### PR TITLE
switch to mailchip form fields

### DIFF
--- a/source/partials/_signup.html.erb
+++ b/source/partials/_signup.html.erb
@@ -1,4 +1,8 @@
-<form id="signup-form" accept-charset="UTF-8" action="https://formkeep.com/f/f87b168aeb37" method="POST">
-  <input type="email" name="email" id="email" placeholder="Email Address" />
-  <input type="submit" value="Send Me Updates" class="button-primary halloween" />
+<form id="signup-form" accept-charset="UTF-8" action="https://empex.us12.list-manage.com/subscribe/post" method="POST">
+  <input type="hidden" name="u" value="9d40dbb0479340efa12eb81d5">
+  <input type="hidden" name="id" value="0869b35918">
+
+  <input type="email" autocapitalize="off" autocorrect="off" name="MERGE0" id="MERGE0" placeholder="Email Address">
+
+  <input type="submit" name="submit" value="Send Me Updates" class="button-primary halloween" />
 </form>


### PR DESCRIPTION
# Switch the urls for our signup forms to go right to mailchip

Followed instructions from https://mailchimp.com/help/host-your-own-signup-forms

I tried it locally, and I'm on the list now:

![screen shot 2018-11-12 at 12 58 55 pm](https://user-images.githubusercontent.com/5178425/48374799-c62c7100-e67a-11e8-81a3-bd1923d58e47.png)

