### PR TITLE
Tweak la design

### DIFF
--- a/config.rb
+++ b/config.rb
@@ -36,6 +36,7 @@ end
 
 page 'index.html', layout: false
 page 'la.html', layout: false
+page 'la-*.html', layout: false
 
 ignore "current_event.html"
 ignore "event.html"

--- a/source/assets/stylesheets/la.scss
+++ b/source/assets/stylesheets/la.scss
@@ -110,16 +110,16 @@ h6 {
 }
 
 .hero-background {
-  background-image: url('/assets/images/la-hero-short.jpeg');
+  background-image: url('/assets/images/la-hero.jpg');
   background-position: top center;
-  /* background-size: cover; */
+  background-size: cover;
 }
 
 .nav {
-  @include section-color(black);
+  @include section-color(white);
 
   a {
-    color: black;
+    color: white;
   }
 
   display: flex;
@@ -135,7 +135,6 @@ h6 {
     line-height: 1;
     font-size: 36px;
     text-transform: uppercase;
-    color: black;
   }
 
   &__spacer {
@@ -167,25 +166,21 @@ h6 {
 .hero {
   @include normal-section();
 
+  min-height: 82vw;
+
   &__content {
     @include section-color(black);
 
-    /* background: rgba(white, 0.5); */
+    background: rgba(white, 0.5);
     padding: 0.5rem;
     margin-top: 2rem;
 
     @include media-tablet {
-      /* background: transparent; */
+      background: transparent;
       padding: 0;
       margin-top: 12rem;
     }
-
-    h2, p {
-      color: white;
-    }
   }
-
-  padding-bottom: 20px;
 
   &__presents {
     margin-bottom: 0;
@@ -223,21 +218,40 @@ h6 {
 }
 
 .about {
-  &__content-color {
-    background: $background-black;
-    @include section-color(white);
-  }
+  @include small-section();
+  @include section-color(white);
 
-  &__content {
-    @include small-section();
-    padding-top: $section-margin;
-    padding-bottom: $section-margin;
-  }
-  /* background: $background-black; */
-  /* @include section-color(white); */
-  /* @include small-section(); */
-  /* @include section-color(white); */
+  #signup-form {
+    margin-top: 2rem;
+    margin-bottom: 0;
 
+    @include display-flex;
+    position: relative;
+
+    @include media-tablet {
+      input[type='text'],
+      input[type='password'],
+      input[type='email'] {
+        width: 18em;
+      }
+
+      > * {
+        margin: 0 0 0 1em;
+      }
+
+      > :first-child {
+        margin: 0 0 0 0;
+      }
+    }
+
+    #email {
+      @include city-input();
+    }
+
+    input.button-primary {
+      @include city-button(#DA604B, white);
+    }
+  }
 }
 
 .location {
@@ -297,22 +311,12 @@ h6 {
   @include section-color($color0);
 }
 
-.sponsors {
-  &__content-color {
-    background: $background-black;
-    @include section-color(white);
-  }
-
-  &__content {
-    @include small-section();
-    margin-top: $section-margin;
-    margin-bottom: $section-margin;
-  }
-  /* @include small-section(); */
-  /* @include section-color(white); */
-  /* background: $color0; */
-  /* margin-top: 5rem; */
-  /* margin-bottom: 5rem; */
+.sponsor-section {
+  @include small-section();
+  @include section-color(white);
+  background: $color0;
+  margin-top: 5rem;
+  margin-bottom: 5rem;
 
   a.image-link {
     &:hover {
@@ -471,10 +475,6 @@ h6 {
   background: black;
 }
 
-#signup {
-  @include small-section;
-}
-
 #footer {
   @include transition(opacity 0.2s ease-in-out);
   text-align: center;
@@ -525,37 +525,5 @@ h6 {
   .crevalle-name {
     height: 16px;
     width: 92px;
-  }
-}
-
-#signup-form {
-  margin-top: 2rem;
-  margin-bottom: 0;
-
-  @include display-flex;
-  position: relative;
-
-  @include media-tablet {
-    input[type='text'],
-    input[type='password'],
-    input[type='email'] {
-      width: 18em;
-    }
-
-    > * {
-      margin: 0 0 0 1em;
-    }
-
-    > :first-child {
-      margin: 0 0 0 0;
-    }
-  }
-
-  #email {
-    @include city-input();
-  }
-
-  input.button-primary {
-    @include city-button(#DA604B, white);
   }
 }

--- a/source/assets/stylesheets/la.scss
+++ b/source/assets/stylesheets/la.scss
@@ -1,4 +1,4 @@
-@import './2018-styles';
+@import "./2018-styles";
 
 $h3: 22px;
 $p: 16px;
@@ -27,10 +27,15 @@ h6 {
   h5,
   h6 {
     color: $color;
+
+    a {
+      // Links in text should still be highlighted.
+      color: #1eaedb;
+    }
   }
 }
 
-@mixin city-input($background: rgba(gray, 0.25),$border: gray) {
+@mixin city-input($background: rgba(gray, 0.25), $border: gray) {
   background: $background;
   padding: 2.375rem 2.875rem;
   font-size: $p;
@@ -86,7 +91,7 @@ h6 {
 
   &::after {
     @include small-section();
-    content: '';
+    content: "";
     height: 1px;
     padding: 0;
     display: block;
@@ -110,9 +115,18 @@ h6 {
 }
 
 .hero-background {
-  background-image: url('/assets/images/la-hero.jpg');
+  background-image: url("/assets/images/la-hero.jpg");
   background-position: top center;
   background-size: cover;
+}
+
+.hero__text {
+  line-height: 1.3;
+  margin-bottom: 1rem;
+  // Make the main text in the hero image not run over the palm tree.
+  @include tablet {
+    width: 70%;
+  }
 }
 
 .nav {
@@ -220,38 +234,7 @@ h6 {
 .about {
   @include small-section();
   @include section-color(white);
-
-  #signup-form {
-    margin-top: 2rem;
-    margin-bottom: 0;
-
-    @include display-flex;
-    position: relative;
-
-    @include media-tablet {
-      input[type='text'],
-      input[type='password'],
-      input[type='email'] {
-        width: 18em;
-      }
-
-      > * {
-        margin: 0 0 0 1em;
-      }
-
-      > :first-child {
-        margin: 0 0 0 0;
-      }
-    }
-
-    #email {
-      @include city-input();
-    }
-
-    input.button-primary {
-      @include city-button(#DA604B, white);
-    }
-  }
+  overflow: auto;
 }
 
 .location {
@@ -467,6 +450,38 @@ h6 {
       font-size: 1em;
       line-height: 1.25em;
     }
+  }
+}
+
+#signup-form {
+  margin: 2rem 0;
+
+  @include display-flex;
+  justify-content: center;
+  position: relative;
+
+  @include media-tablet {
+    input[type="text"],
+    input[type="password"],
+    input[type="email"] {
+      width: 18em;
+    }
+
+    > * {
+      margin: 0 0 0 1em;
+    }
+
+    > :first-child {
+      margin: 0 0 0 0;
+    }
+  }
+
+  #email {
+    @include city-input();
+  }
+
+  input.button-primary {
+    @include city-button(#da604b, white);
   }
 }
 

--- a/source/la.html.erb
+++ b/source/la.html.erb
@@ -42,7 +42,7 @@
     <section class="hero">
       <nav class="nav">
         <div class="nav__empex">
-          EMPEX
+          <strong>EMPEX</strong>
           <br class="hide-tablet"/>
 
           Los Angeles
@@ -98,21 +98,19 @@
         </a>
       </div>
     </section>
+
+    <section id="about" class="about">
+      <h2>About</h2>
+      <p>
+        With the emergence of the concurrent Elixir programming language, we believe that all web
+        applications should have realtime interfaces.  We're bringing together leading designers,
+        engineers, product managers, and database specialists to explore design patterns,
+        considerations, and possibilities in this exciting new world.
+      </p>
+    </section>
   </div>
 
-  <section id="about" class="about">
-    <div class="about__content-color">
-      <div class="about__content">
-        <h2>About</h2>
-        <p>
-          With the emergence of the concurrent Elixir programming language, we believe that all web
-          applications should have realtime interfaces.  We're bringing together leading designers,
-          engineers, product managers, and database specialists to explore design patterns,
-          considerations, and possibilities in this exciting new world.
-        </p>
-      </div>
-    </div>
-  </section>
+  <div class="hr hr--black"></div>
 
   <section id="location" class="location">
     <div class="location__content-color">

--- a/source/la.html.erb
+++ b/source/la.html.erb
@@ -83,7 +83,7 @@
           <span class="hero__crevalle"><a href="http://crevalle.io" target="_blank">Crevalle</a></span>
           presents:
         </p> %>
-        <h2>
+        <h2 class="hero__text">
           A one-day conference exploring development of realtime applications.
         </h2>
         <p>
@@ -148,20 +148,20 @@
     </div>
   </section>
 
-  <section id="sponsors" class="sponsors">
-    <div class="sponsors__content-color">
-      <div class="sponsors__content">
-        <h2>Sponsors</h2>
+  <section id="sponsors" class="sponsor-section">
+    <section class="sponsor-list">
+      <h2>Sponsors</h2>
+    </section>
 
-        <div>
-          <p>
-            Please join us!  Our sponsorship prospectus is available <a href="https://docs.google.com/document/d/13AaTTTRUQk6XgTo9GJzFuh7IDzDF9t-F1XebmX_PAEI/edit">here</a>.
-          </p>
-          <p>
-            If you're interested in sponsoring EMPEX, please contact us at
-            <a href="mailto:info@empex.co">info@empex.co</a>.
-          </p>
-        </div>
+    <div class="footer">
+      <div>
+        <p>
+          Please join us!  Our sponsorship prospectus is available <a href="https://docs.google.com/document/d/13AaTTTRUQk6XgTo9GJzFuh7IDzDF9t-F1XebmX_PAEI/edit">here</a>.
+        </p>
+        <h4>
+          If you're interested in sponsoring EMPEX, please contact us at
+          <a href="mailto:info@empex.co">info@empex.co</a>.
+        </h4>
       </div>
     </div>
   </section>


### PR DESCRIPTION
Looks like the design got a little messed up on the LA pages. I reverted some changes to the `la.scss` file and some of the markup on the la page, which seems to have helped. The big difference is the about section should go inside the Hero section, which is weird but makes the image flow into the page nicely.

I also updated the config to stop injecting the NYC headers into any of the LA pages, since that was causing some unexpected white spaces.

![hero](https://user-images.githubusercontent.com/5178425/61525661-b7e2e180-a9cd-11e9-8432-ac5a2c799014.png)
![footer](https://user-images.githubusercontent.com/5178425/61525660-b7e2e180-a9cd-11e9-988a-49f92d665b69.png)